### PR TITLE
Dirty fix for #4

### DIFF
--- a/custom_components/allpowers_ble/allpowers.py
+++ b/custom_components/allpowers_ble/allpowers.py
@@ -260,25 +260,26 @@ class AllpowersBLE:
 
         self._buf += data
 
-        battery_percentage = data[8]
-        dc_on = data[7] >> 0 & 1 == 1
-        ac_on = data[7] >> 1 & 1 == 1
-        torch_on = data[7] >> 4 & 1 == 1
-        output_power = (256 * data[11]) + data[12]
-        input_power = (256 * data[9]) + data[10]
-        minutes_remaining = (256 * data[13]) + data[14]
+        if len(data) > 14:
+            battery_percentage = data[8]
+            dc_on = data[7] >> 0 & 1 == 1
+            ac_on = data[7] >> 1 & 1 == 1
+            torch_on = data[7] >> 4 & 1 == 1
+            output_power = (256 * data[11]) + data[12]
+            input_power = (256 * data[9]) + data[10]
+            minutes_remaining = (256 * data[13]) + data[14]
 
-        self._state = AllpowersState(
-            ac_on=ac_on,
-            dc_on=dc_on,
-            light_on=torch_on,
-            percent_remain=battery_percentage,
-            minutes_remain=minutes_remaining,
-            watts_export=output_power,
-            watts_import=input_power,
-        )
+            self._state = AllpowersState(
+                ac_on=ac_on,
+                dc_on=dc_on,
+                light_on=torch_on,
+                percent_remain=battery_percentage,
+                minutes_remain=minutes_remaining,
+                watts_export=output_power,
+                watts_import=input_power,
+            )
 
-        self._fire_callbacks()
+            self._fire_callbacks()
 
         _LOGGER.debug(
             "%s: Notification received; RSSI: %s: %s %s",


### PR DESCRIPTION
After some investigating I found out that my R600 sometimes report only 14 bytes data via BT and sometimes it reports 16 bytes. From the code it seems that 16 bytes is the correct payload therefore I put the logic in the `if` statement. Not sure if this should be the solution, but at least my haas logs are not spammed with millions of exceptions.

Here is an example of malformed payload that my R600 emits:
```
a5 65 b1 00 01 06 03 02 01 00 00 03 02 77
```
and here are the correct ones:
```
a5 65 b1 00 01 08 01 02 64 00 00 00 28 01 56 60
a5 65 b1 00 01 08 01 02 64 00 00 00 27 01 5e 67
a5 65 b1 00 01 08 01 02 64 00 00 00 2a 01 47 73
```