### PR TITLE
Fix IndexError: bytearray index out of range

### DIFF
--- a/custom_components/allpowers_ble/allpowers.py
+++ b/custom_components/allpowers_ble/allpowers.py
@@ -260,6 +260,8 @@ class AllpowersBLE:
 
         self._buf += data
 
+        if len(data) <= 14: return
+
         battery_percentage = data[8]
         dc_on = data[7] >> 0 & 1 == 1
         ac_on = data[7] >> 1 & 1 == 1


### PR DESCRIPTION
This is a cleaner patch for the jinglemansweep#4 issue that could replace the jinglemansweep#5 pull request.

A message handler raised an exception: bytearray index out of range

Traceback (most recent call last):
  File "src/dbus_fast/message_bus.py", line 802, in dbus_fast.message_bus.BaseMessageBus._process_message
  File "/usr/local/lib/python3.12/site-packages/bleak/backends/bluezdbus/manager.py", line 1008, in _parse_msg
    watcher.on_characteristic_value_changed(
  File "/usr/local/lib/python3.12/site-packages/bleak/backends/bluezdbus/client.py", line 177, in on_value_changed
    callback(bytearray(value))
  File "/config/custom_components/allpowers_ble/allpowers.py", line 269, in _notification_handler
    minutes_remaining = (256 * data[13]) + data[14]
                                           ~~~~^^^^
IndexError: bytearray index out of range